### PR TITLE
Fix missing include

### DIFF
--- a/android/jni/ed25519/additions/curve_sigs.c
+++ b/android/jni/ed25519/additions/curve_sigs.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdlib.h>
 #include "ge.h"
 #include "curve_sigs.h"
 #include "crypto_sign.h"


### PR DESCRIPTION
This file makes calls to malloc() and free(), without including the header file that declares them.
