### PR TITLE
Fix missing function declaration

### DIFF
--- a/android/jni/ed25519/additions/crypto_additions.h
+++ b/android/jni/ed25519/additions/crypto_additions.h
@@ -16,6 +16,7 @@ void fe_mont_rhs(fe v2, const fe u);
 void fe_montx_to_edy(fe y, const fe u);
 void fe_sqrt(fe b, const fe a);
 
+int ge_is_small_order(const ge_p3 *p);
 int ge_isneutral(const ge_p3* q);
 void ge_neg(ge_p3* r, const ge_p3 *p);
 void ge_montx_to_p3(ge_p3* p, const fe u, const unsigned char ed_sign_bit);


### PR DESCRIPTION
This function is called from "uopen_modified.c" without being declared in anything included by that source file. Putting the declaration here fixes that issue.
