### PR TITLE
README: updated signature example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ byte[]     sharedSecret = cipher.calculateAgreement(publicKey, privateKey);
 
 ```
 Curve25519 cipher    = Curve25519.getInstance(Curve25519.BEST);
-byte[]     signature = cipher.calculateSignature(secureRandom, privateKey, message);
+byte[]     signature = cipher.calculateSignature(privateKey, message);
 ```
 
 ### Verifying a signature:


### PR DESCRIPTION
The method `calculateSignature` of `Curve25519` instances doesn't take an explicit `random` parameter since 0f10718, but rather generates it implicitly before passing it on to the provider.