### PR TITLE
Add targetSdk to Android build to avoid automatically added permissions.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,8 +17,12 @@ version          = version_number
 group            = group_info
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
+
+    defaultConfig {
+        targetSdkVersion 4
+    }
 
     sourceSets {
         main {


### PR DESCRIPTION
Fixes issue #14 
When using the Android library and both minSdk and targetSdk are missing, the app gets "featured" automatically with three sensitive permissions, which did not exist before Android API level 4.

References
https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_STATE
https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE:
